### PR TITLE
Allowing cross compilation with e.g. buildroot

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -1,14 +1,6 @@
 {
     "variables": {
-	    "conditions": [
-	        ['BR2_VERSION!=""', {
-                "root_dir%": '$(TARGET_DIR)'
-            }],
-            ['BR2_VERSION==""', {
-                "root_dir%": ''
-            }],
-	  
-	  ]
+        'root_dir': "<!(echo '$(TARGET_DIR)')",
     },
     "targets": [{
         "target_name": "timeswipe",

--- a/binding.gyp
+++ b/binding.gyp
@@ -1,4 +1,15 @@
 {
+    "variables": {
+	    "conditions": [
+	        ['BR2_VERSION!=""', {
+                "root_dir%": '$(TARGET_DIR)'
+            }],
+            ['BR2_VERSION==""', {
+                "root_dir%": ''
+            }],
+	  
+	  ]
+    },
     "targets": [{
         "target_name": "timeswipe",
         "cflags!": [ "-fno-exceptions", "-Wall" ],
@@ -9,10 +20,10 @@
         'include_dirs': [
             "<!@(node -p \"require('node-addon-api').include\")",
             "<!@(node -p \"require('napi-thread-safe-callback').include\")",
-            "$(TARGET_DIR)/usr/include"
+            "<(root_dir)/usr/include"
         ],
         'libraries': [
-            "$(TARGET_DIR)/usr/lib/libtimeswipe.so",
+            "<(root_dir)/usr/lib/libtimeswipe.so",
         ],
         'dependencies': [
             "<!(node -p \"require('node-addon-api').gyp\")"

--- a/binding.gyp
+++ b/binding.gyp
@@ -8,10 +8,12 @@
         ],
         'include_dirs': [
             "<!@(node -p \"require('node-addon-api').include\")",
-            "<!@(node -p \"require('napi-thread-safe-callback').include\")"
+            "<!@(node -p \"require('napi-thread-safe-callback').include\")",
+            "$(TARGET_DIR)/usr/include"
         ],
         'libraries': [
             "/usr/lib/libtimeswipe.so",
+            "$(TARGET_DIR)/usr/lib/libtimeswipe.so",
         ],
         'dependencies': [
             "<!(node -p \"require('node-addon-api').gyp\")"

--- a/binding.gyp
+++ b/binding.gyp
@@ -12,7 +12,6 @@
             "$(TARGET_DIR)/usr/include"
         ],
         'libraries': [
-            "/usr/lib/libtimeswipe.so",
             "$(TARGET_DIR)/usr/lib/libtimeswipe.so",
         ],
         'dependencies': [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeswipe",
-  "version": "0.0.4a",
+  "version": "0.0.4",
   "description": "TimeSwipe js NAPI",
   "main": "index.js",
   "gypfile": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "timeswipe",
-  "version": "0.0.4",
+  "version": "0.0.4a",
   "description": "TimeSwipe js NAPI",
   "main": "index.js",
   "gypfile": true,


### PR DESCRIPTION
The variable $(TARGET_DIR) will output the root directory of the target when compiling with buildroot. Therefore, node-gyp can find the right headers and libraries.
Please check if normal compilation is still possible with this variable.